### PR TITLE
update understream for Zalgo fixes in map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unix-sort",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "unix-sort",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
The name of the branch refers to the error (an gearman-node bug) that is expressed because we are locking up the `node event loop` for too long
